### PR TITLE
Fixing filepath of groups and communicators image

### DIFF
--- a/lessons/mpi/mpi-c.ipynb
+++ b/lessons/mpi/mpi-c.ipynb
@@ -387,7 +387,7 @@
     "\n",
     "Groups are a related but distinct concept to communicators.  Groups describe a set of processes, while communicators provide a context for processes to share information (through message-passing).  Communicators come in two forms, intracommuncators which are used for communication between processes in the same group, and intercommunicators which allow for communication between disjoint groups.  Since only one group and one communicator exist a the beginning of a program, `MPI_COMM_WORLD` is an example of an intracommunicator.  Intercommunicators are only necessary when subcommunicators are created and communication between two subcommunicators is desired.  We'll illustrate these comments with the following image.\n",
     "\n",
-    "![](https://raw.githubusercontent.com/maxim-belkin/hpc-sp16/gh-pages/lessons/img/Groups and Communicators.png)\n",
+    "![](https://raw.githubusercontent.com/maxim-belkin/hpc-sp16/gh-pages/lessons/mpi/img/Groups and Communicators.png)\n",
     "\n",
     "In this graphic, 16 separate processes (P<sub>0</sub>-P<sub>15</sub>) are represented with diamonds.  Each of these processes belongs to one of four groups, each group being associated with an intracommunicator (Comm<sub>3</sub>-Comm<sub>6</sub>).  However, each process is also associated with 2 other communicators, one of either Comm<sub>1</sub>, which contains all the processes in groups 1 and 2, or Comm<sub>2</sub>, which contain all the processes in groups 2 and 3, and the global communicator, `MPI_COMM_WORLD`.  Keep in mind that communicators aren't tracked with a rank or number, but a variable that you define, the numbers are just here for reference.\n",
     "\n",
@@ -568,7 +568,7 @@
    "metadata": {},
    "source": [
     "### Exercise\n",
-    "Write a small program to add the vectors [1 2 3 4 5 6 7 8 9 10] and [10 9 8 7 6 5 4 3 2 1] in parallel."
+    "Write a small program to calculate the dot product of the two vectors [1 2 3 4 5 6 7 8 9 10] and [10 9 8 7 6 5 4 3 2 1] in parallel."
    ]
   },
   {
@@ -579,7 +579,7 @@
    },
    "outputs": [],
    "source": [
-    "%%file vadd.c"
+    "%%file dot.c"
    ]
   },
   {
@@ -591,8 +591,8 @@
    "outputs": [],
    "source": [
     "# To run this code from within the notebook.\n",
-    "!mpicc -o vadd vadd.c\n",
-    "!mpiexec -n 2 ./vadd"
+    "!mpicc -o dot dot.c\n",
+    "!mpiexec -n 2 ./dot"
    ]
   },
   {


### PR DESCRIPTION
The filepath for the new image was missing a directory and so it wasn't showing up.  I also changed the new exercise I added from a vector addition to a dot product so that it actually requires communication.
